### PR TITLE
loosen peer dependencies; add npm prepublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studysync/svg-draw",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "publishConfig": {
     "access": "public"
   },
@@ -43,16 +43,17 @@
     "lint": "eslint . --ext js,json,ts,tsx",
     "lint:fix": "yarn run lint --fix",
     "dev": "parcel src/examples/index.html --port 9000 --no-autoinstall",
-    "graph": "madge --exclude spec.js --image graph.svg src/svgDraw.tsx && open graph.svg"
+    "graph": "madge --exclude spec.js --image graph.svg src/svgDraw.tsx && open graph.svg",
+    "prepublish": "yarn run build"
   },
   "peerDependencies": {
-    "@emotion/react": "11",
-    "@emotion/styled": "11",
-    "@mui/icons-material": "5",
-    "@mui/material": "5",
-    "immer": "9",
-    "react": "17",
-    "react-dom": "17"
+    "@emotion/react": ">=11",
+    "@emotion/styled": ">=11",
+    "@mui/icons-material": ">=5",
+    "@mui/material": ">=5",
+    "immer": ">=9",
+    "react": ">=17",
+    "react-dom": ">=17"
   },
   "devDependencies": {
     "@emotion/react": "11",


### PR DESCRIPTION
Ideally we'd run linting and testing before publishing, however there are no tests and the project currently has numerous linting issues