### PR TITLE
Readonly mode; update immer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studysync/svg-draw",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studysync/svg-draw",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studysync/svg-draw",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "publishConfig": {
     "access": "public"
   },
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/PieceOfMeat/svg-draw.git"
+    "url": "git+https://github.com/PieceOfMeat/svg-draw.git"
   },
   "private": false,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studysync/svg-draw",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "publishConfig": {
     "access": "public"
   },
@@ -96,7 +96,7 @@
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
     "eslint-plugin-testing-library": "5.0.5",
-    "immer": "^10.0.1",
+    "immer": "^10.0.4",
     "madge": "^5.0.1",
     "parcel": "^2.2.1",
     "react": "^18.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@studysync/svg-draw",
-  "version": "0.2.10",
+  "version": "0.2.12",
   "publishConfig": {
     "access": "public"
   },
@@ -51,7 +51,7 @@
     "@emotion/styled": ">=11",
     "@mui/icons-material": ">=5",
     "@mui/material": ">=5",
-    "immer": ">=9",
+    "immer": ">=10",
     "react": ">=18",
     "react-dom": ">=18"
   },
@@ -96,7 +96,7 @@
     "eslint-plugin-react": "7.28.0",
     "eslint-plugin-react-hooks": "4.3.0",
     "eslint-plugin-testing-library": "5.0.5",
-    "immer": "^9.0.14",
+    "immer": "^10.0.1",
     "madge": "^5.0.1",
     "parcel": "^2.2.1",
     "react": "^18.1.0",

--- a/src/SvgDraw.tsx
+++ b/src/SvgDraw.tsx
@@ -88,11 +88,11 @@ export const SvgDraw = ({ data = emptyPage, onChange, readonly = false }: SvgDra
       <Renderer
         containerRef={containerRef}
         grid={grid}
-        hideBounds={false}
+        hideBounds={readonly}
         hideGrid={hideGrid}
-        hideHandles={false}
-        hideIndicators={false}
-        hideRotateHandles={false}
+        hideHandles={readonly}
+        hideIndicators={readonly}
+        hideRotateHandles={readonly}
         meta={meta}
         onDoubleClickShape={handleCallback('onDoubleClickShape')}
         onDragBoundsHandle={handleCallback('onDragBoundsHandle')}
@@ -119,7 +119,7 @@ export const SvgDraw = ({ data = emptyPage, onChange, readonly = false }: SvgDra
         pageState={pageState}
         shapeUtils={stateManager.utils}
       />
-      <Toolbar />
+      <Toolbar readonly={readonly} />
     </StateManagerContext.Provider>
   )
 }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,4 +1,4 @@
-import React, { useSyncExternalStore } from 'react'
+import React, { useEffect, useSyncExternalStore } from 'react'
 import Box from '@mui/material/Box'
 import AppBar from '@mui/material/AppBar'
 import { useTheme } from '@mui/material/styles'
@@ -51,16 +51,22 @@ const DrawToolbar = React.memo(({ readonly }: DrawToolbarProps) => {
     pageState.setSettings({ hideGrid: !hideGrid })
   }
 
+  useEffect(() => {
+    if (readonly) stateManager.setTool(TDToolType.Select)
+  }, [readonly, stateManager])
+
   return (
     <Box m="auto" p={1} width="fit-content">
       <AppBar color="transparent" position="static">
         <Toolbar disableGutters={styles.noGutters} variant="dense">
-          <ToggleButtonGroup exclusive onChange={onToolChange} size={styles.size} value={toolbarState.tool}>
-            {toolsList.map(tool => toolbarButton({
-              isVisible: !readonly && toolbar.isVisible(tool.type),
-              ...tool,
-            }))}
-          </ToggleButtonGroup>
+          {!readonly && (
+            <ToggleButtonGroup exclusive onChange={onToolChange} size={styles.size} value={toolbarState.tool}>
+              {toolsList.map(tool => toolbarButton({
+                isVisible: !readonly && toolbar.isVisible(tool.type),
+                ...tool,
+              }))}
+            </ToggleButtonGroup>
+          )}
 
           <ToggleButton
             onChange={handleShowGridChange}
@@ -73,7 +79,7 @@ const DrawToolbar = React.memo(({ readonly }: DrawToolbarProps) => {
             <BorderClearIcon />
           </ToggleButton>
 
-          <StylesSelector />
+          {!readonly && <StylesSelector />}
         </Toolbar>
       </AppBar>
     </Box>

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -25,7 +25,11 @@ const toolbarButton = ({ title, type, Icon, isVisible }: ToolbarBtnProps) => {
   )
 }
 
-const DrawToolbar = React.memo(() => {
+type DrawToolbarProps = {
+  readonly: boolean,
+}
+
+const DrawToolbar = React.memo(({ readonly }: DrawToolbarProps) => {
   const stateManager = useStateManager()
   const { pageState, toolbar } = stateManager
   const toolbarState = useSyncExternalStore(toolbar.subscribe, () => toolbar.state)
@@ -53,7 +57,7 @@ const DrawToolbar = React.memo(() => {
         <Toolbar disableGutters={styles.noGutters} variant="dense">
           <ToggleButtonGroup exclusive onChange={onToolChange} size={styles.size} value={toolbarState.tool}>
             {toolsList.map(tool => toolbarButton({
-              isVisible: toolbar.isVisible(tool.type),
+              isVisible: !readonly && toolbar.isVisible(tool.type),
               ...tool,
             }))}
           </ToggleButtonGroup>

--- a/src/state/shapes/FreeDraw/FreeDrawShape.ts
+++ b/src/state/shapes/FreeDraw/FreeDrawShape.ts
@@ -1,4 +1,4 @@
-import produce from 'immer'
+import { produce } from 'immer'
 import { TDShapeStyle, TDShapeStyleKeys, TDShapeType, Transformable, TransformedBounds } from 'types'
 import BaseShape, { BaseEntity, BaseShapeCreateProps } from 'state/shapes/BaseShape'
 import { getBoundsFromPoints, translateBounds, translatePoints } from 'utils'

--- a/src/state/stores/store.ts
+++ b/src/state/stores/store.ts
@@ -1,4 +1,4 @@
-import produce from 'immer'
+import { produce } from 'immer'
 
 type CBFunction<T> = (state: T) => void
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,9 +2357,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001286:
-  version "1.0.30001473"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001473.tgz"
-  integrity sha512-ewDad7+D2vlyy+E4UJuVfiBsU69IL+8oVmTuZnH5Q6CIUbxNfI50uVpRHbUPDD6SUaN2o0Lh4DhTrvLG/Tn1yg==
+  version "1.0.30001608"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001608.tgz"
+  integrity sha512-cjUJTQkk9fQlJR2s4HMuPMvTiRggl0rAVMtthQuyOlDWuqHXqN8azLq+pi8B2TjwKJ32diHjUqRIKeFX4z1FoA==
 
 ccount@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4331,7 +4331,7 @@ ignore@^5.1.8, ignore@^5.2.0:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-immer@^10.0.1:
+immer@^10.0.4:
   version "10.0.4"
   resolved "https://registry.yarnpkg.com/immer/-/immer-10.0.4.tgz#09af41477236b99449f9d705369a4daaf780362b"
   integrity sha512-cuBuGK40P/sk5IzWa9QPUaAdvPHjkk1c+xYsd9oZw+YQQEV+10G0P5uMpGctZZKnyQ+ibRO08bD25nWLmYi2pw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4331,10 +4331,10 @@ ignore@^5.1.8, ignore@^5.2.0:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
-immer@^9.0.14:
-  version "9.0.14"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.14.tgz#e05b83b63999d26382bb71676c9d827831248a48"
-  integrity sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw==
+immer@^10.0.1:
+  version "10.0.4"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.0.4.tgz#09af41477236b99449f9d705369a4daaf780362b"
+  integrity sha512-cuBuGK40P/sk5IzWa9QPUaAdvPHjkk1c+xYsd9oZw+YQQEV+10G0P5uMpGctZZKnyQ+ibRO08bD25nWLmYi2pw==
 
 import-fresh@^3.0.0, import-fresh@^3.1.0, import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
The frontend requires immer v10.x

I also made some edits so that readonly takes effect immediately and hides some tools when engaged